### PR TITLE
【確認待ち】投稿トップに指定した固定ページでページヘッダーの設定 metabox が表示されないように

### DIFF
--- a/vk-page-header/package/class-vk-page-header.php
+++ b/vk-page-header/package/class-vk-page-header.php
@@ -694,12 +694,13 @@ if ( ! class_exists( 'Vk_Page_Header' ) ) {
 		/*-------------------------------------------*/
 		/* static にすると環境によってmetabox内のコールバック関数が反応しない */
 		public function add_pagehead_setting_meta_box() {
-			global $post;
-			$page_for_posts = (int) get_option( 'page_for_posts' );
-
-			if ( $page_for_posts !== $post->ID ) {
-				add_meta_box( 'vk_page_header_meta_box', __( 'Page Header Image', 'vk_page_header_textdomain' ), array( $this, 'vk_page_header_meta_box_content' ), 'page', 'normal', 'high' );
+			// 投稿トップは固定ページでなくアーカイプページ判定されるので、
+			// 投稿トップにわりあてた固定ページで指定したカラム数は反映されない。
+			// よって、誤解を避けるためにレイアウト設定を含む Lightningデザイン設定のmetabox自体表示しないようにする
+			if ( isset( $_GET['post'] ) && $_GET['post'] === get_option( 'page_for_posts' ) && 'page' === get_option( 'show_on_front' ) ){
+				return;
 			}
+			add_meta_box( 'vk_page_header_meta_box', __( 'Page Header Image', 'vk_page_header_textdomain' ), array( $this, 'vk_page_header_meta_box_content' ), 'page', 'normal', 'high' );
 		}
 
 		public function vk_page_header_meta_box_content() {

--- a/vk-page-header/package/class-vk-page-header.php
+++ b/vk-page-header/package/class-vk-page-header.php
@@ -694,8 +694,12 @@ if ( ! class_exists( 'Vk_Page_Header' ) ) {
 		/*-------------------------------------------*/
 		/* static にすると環境によってmetabox内のコールバック関数が反応しない */
 		public function add_pagehead_setting_meta_box() {
+			global $post;
+			$page_for_posts = (int) get_option( 'page_for_posts' );
 
-			add_meta_box( 'vk_page_header_meta_box', __( 'Page Header Image', 'vk_page_header_textdomain' ), array( $this, 'vk_page_header_meta_box_content' ), 'page', 'normal', 'high' );
+			if ( $page_for_posts !== $post->ID ) {
+				add_meta_box( 'vk_page_header_meta_box', __( 'Page Header Image', 'vk_page_header_textdomain' ), array( $this, 'vk_page_header_meta_box_content' ), 'page', 'normal', 'high' );
+			}
 		}
 
 		public function vk_page_header_meta_box_content() {


### PR DESCRIPTION
【変更点】
投稿トップに指定した固定ページでページヘッダーの設定 metabox が表示されないようにしました。

関連 Issue: https://github.com/vektor-inc/lightning-pro/issues/100

---

【確認手順・確認条件】
1. ```gulp copy_page-header``` を実行
2. 外観 > カスタマイズ > ホームページ設定 or 設定 > 表示設定 と進む
3. 「ホームページの表示」を固定ページにし「ホームページ」と「投稿ページ」を設定
4. 「投稿ページ」に設定された固定ページにページヘッダーの設定 metabox がないことを確認

---

【確認事項】
- Lightning Pro や Katawara で使用している Page Header と G3 で使用しているものは異なりますか？ ⇒ @kurudrive 
