### PR TITLE
【石川確認中】Tree Shaking を更新

### DIFF
--- a/vk-css-optimize/package/class-css-tree-shaking.php
+++ b/vk-css-optimize/package/class-css-tree-shaking.php
@@ -7,252 +7,376 @@ If you want to change this file, please change the original file.
 /**
  * CSS Simple Tree Shaking
  *
- * Description: CSS 定義データから未使用の id, class, tag に関する定義を取り除き縮小化します
+ * Description: CSS tree shaking minify library
  *
- * Version: 1.0.2
+ * Version: 2.1.0
  * Author: enomoto@celtislab
  * Modefied: Vektor:Inc.
  * Author URI: https://celtislab.net/
  * License: GPLv2
+ *
  */
-namespace celtislab;
+namespace celtislab\v2_1;
 
 defined( 'ABSPATH' ) || exit;
 
+
 class CSS_tree_shaking {
 
-	private static $cmplist;
-	private static $varlist;
-	private static $jsaddlist;
-	private static $atrule_data;
+    private static $cmplist;
+    private static $jsaddlist;
+
+    const  SHAKING_PATTERN = '#@(?<pref>\-[\w]+\-)?(?<atname>((keyframes|supports|media|container|layer)[^\{]+?))\{(?<atstyle>.*?\})\}|@([^;\{\}]+?)(;|\{.*?\})|(?<sel>.+?)\{(?<pv>.+?)\}#u';
+
 	function __construct() {}
 
-	// アットルール一時退避( @{md5key} に置き換えておく)
-	private static function atrule_store( $css ) {
-		$pattern = array(
-			'|(@(\-[\w]+\-)?keyframes.+?\{)(.+?\})\}|',
-			'|(@(\-[\w]+\-)?supports.+?\{)(.+?\})\}|',
-			'|(@(\-[\w]+\-)?media.+?\{)(.+?\})\}|',
-			'|@[^;\{]+?;|',
-			'|@[^;\{]+?\{(.+?)\}|',
-		);
-		foreach ( $pattern as $atrule ) {
-			$css = preg_replace_callback(
-				$atrule,
-				function( $matches ) {
-					$key  = 'AR_' . md5( $matches[0] );
-					$data = $matches[0];
-					if ( ! empty( $matches[3] ) ) {
-						$incss = self::atrule_store( $matches[3] );
-						$incss = self::tree_shaking( $incss );
-						$data  = ( ! empty( $incss ) ) ? $matches[1] . $incss . '}' : '';
-					}
-					self::$atrule_data[ $key ] = $data;
-					return '@{' . $key . '}';
-				},
-				$css
+    //上書きカスタムCSS(simple_minify済)をセレクタ(md5),プロパティ,値の配列にする
+    //※セレクタが複数の場合も考慮して完全同一記述のセレクタのみを簡潔に重複判定出来るよう md5 を使用
+    public static function create_csslist($cusomcss, &$csslist) {
+        if(preg_match_all( self::SHAKING_PATTERN, $cusomcss, $matches, PREG_SET_ORDER)){
+            foreach ($matches as $style) {
+                if(!empty($style['atname'])){
+                    $atkey = md5(trim($style['pref'] . $style['atname']));
+                    if(preg_match_all( '#(?<sel>.+?)\{(?<pv>.+?)\}#u', $style['atstyle'], $atcustoms, PREG_SET_ORDER)){
+                        foreach ($atcustoms as $subitem) {
+                            self::_create_csslist($atkey, $subitem['sel'], $subitem['pv'], $csslist);
+                        }
+                    }
+                } elseif(!empty($style['sel'])) {
+                    self::_create_csslist(0, $style['sel'], $style['pv'], $csslist);
+                }
+            }
+        }
+    }
+    private static function _create_csslist($key, $sel, $pv, &$csslist) {
+        $sel = md5(trim($sel));
+        $pv  = array_map("trim", preg_split("|[:;]|", $pv));
+        $pcnt= count($pv);
+        for($i=0; $i<$pcnt; $i += 2){
+            if(empty($pv[$i]))
+                break;
+            $csslist[ $key ][ $sel ][ $pv[$i] ] = $pv[$i+1];
+        }
+    }
+
+    //selector 内の :not :where :is :has 疑似クラスを退避(カッコ内の,区切りによるセレクタ誤解析回避のため)
+    public static function evacuate_pseudo($selector, &$temp) {
+        $newsel = '';
+        $ofset = 0;
+        $maxlen = strlen($selector);
+        while($ofset < $maxlen){
+            if(preg_match('#(:not|:where|:is|:has)\(#u', substr($selector, $ofset), $omatch)){
+                $open = strpos($selector, $omatch[0], $ofset) + strlen($omatch[0]);
+                if($ofset < $open){
+                    $newsel .= substr($selector, $ofset, $open - $ofset);
+                }
+                $ofset = $open;
+                $depth = 1;
+                while($depth > 0){
+                    if(preg_match('#(\(|\))#u', substr($selector, $ofset), $cmatch)){
+                        $ofset = strpos($selector, $cmatch[0], $ofset) + strlen($cmatch[0]);
+                        if($cmatch[1] == '('){
+                            $depth++;
+                        } else{
+                            $depth--;
+                        }
+                        if($depth === 0){
+                            $replace = substr($selector, $open, $ofset - $open - 1);
+                            $pskey = md5($replace);
+                            $temp[$pskey] = $replace;
+                            $newsel .= $pskey . ')';
+                        }
+                    } else {
+                        $newsel .= substr($selector, $ofset);
+                        $ofset = $maxlen;
+                        break;
+                    }
+                }
+            } else {
+                $newsel .= substr($selector, $ofset);
+                break;
+            }
+        }
+        return $newsel;
+    }
+
+    //selector 内の :not :where :is :has 疑似クラスを復元
+    public static function restore_pseudo($selector, &$temp) {
+        if(!empty($temp)){
+            $selector = preg_replace_callback( '#(:not|:where|:is|:has)\((.*?)\)#u', function($match) use(&$temp) {
+                $kv = $match[2];
+                if(!empty($kv) && isset($temp[ $kv ])){
+                    $kv = $temp[ $kv ];
+                }
+                return $match[1] . '(' . $kv . ')';
+            }, $selector);
+        }
+        return $selector;
+    }
+
+    //CSS から未使用の id, class, tag を含む定義を削除
+    private static function tree_shaking($css, $customcsslist=array(), $atkey='') {
+        $ncss = preg_replace_callback( self::SHAKING_PATTERN, function($mstyle) use(&$customcsslist, &$atkey) {
+            $data = $mstyle[0];
+            if(!empty($mstyle['atname'])){
+                $atkey = md5(trim($mstyle['pref'] . $mstyle['atname']));
+                $atcss = self::tree_shaking( $mstyle['atstyle'], $customcsslist, $atkey );
+                $atkey = ''; //key clear
+                $data  = (!empty($atcss))? '@' . trim($mstyle['pref'] . $mstyle['atname']) . '{' . $atcss . '}' : '';
+
+            } elseif(!empty($mstyle['sel'])) {
+                $sel = $mstyle['sel'];
+                $pv  = $mstyle['pv'];
+                if(!empty($customcsslist)){
+                    //tree shaking 前に上書きカスタムCSSとの重複あれば該当プロパティを削除
+                    $atkey = (!empty($atkey))? $atkey : 0;
+                    $skey  = md5(trim($sel));
+                    if(!empty($customcsslist[$atkey][$skey])){
+                        $_pv  = array_map("trim", preg_split("|[:;]|", $pv));
+                        $pcnt= count($_pv);
+                        for($i=0; $i<$pcnt; $i += 2){
+                            if(!empty($_pv[$i]) && isset( $customcsslist[ $atkey ][ $skey ][ $_pv[$i] ] )){
+                                $pv = preg_replace( '/(^|;|\s)(' . preg_quote($_pv[$i]) . ')\s?:.*?(url\([^\)]+?\).*?)?(;|$)/u', '$1', $pv, 1 );
+                            }
+                        }
+                        if(!empty($pv)){
+                            $pv = preg_replace('/\s+/su', ' ', $pv);
+                            $pv = trim($pv);
+                        }
+                    }
+                }
+                $pattern = array( 'id'       => '|(#)([\w\-\\%]+)|u',
+                                  'class'    => '|(\.)([\w\-\\%]+)|u',
+                                  'tag'      => '/(^|[,\s>\+~\(\)\]\|])([\w\-]+)/iu',
+                                );
+
+                $pseudo = array();
+                $sel = self::evacuate_pseudo($sel, $pseudo);
+                $slist = array_map("trim", explode(',', $sel));
+                foreach ($slist as $s) {
+                    //selector の判定条件から :not :where :is :has を除外 ($_s で判定して削除時は $s で行う)
+                    $_s = $s;
+                    foreach (array(':not',':where',':is',':has') as $psd) {
+                        if(strpos($_s, $psd) !== false){
+                            $_s = preg_replace("/$psd\(.+?\)/", '', $_s );
+                        }
+                    }
+                    foreach (array('id','class','tag') as $item) {
+                        if(!empty($_s) && preg_match_all( $pattern[$item], $_s, $match)){
+                            foreach ($match[2] as $v) {
+                                //$jsaddlist 登録名が含まれていれば削除しない（処理を簡略化するため上位層のセレクタのみで判定）
+                                if(isset(self::$jsaddlist[$v]))
+                                    break;
+
+                                //$cmplist 登録名に含まれていなければ削除
+                                $delfg = false;
+                                if(!isset(self::$cmplist[$item][$v]) && !preg_match('/^[0-9]+/', $v)){
+                                    $delfg = true;
+                                } elseif($item === 'tag' && preg_match('#\[type\s?=\s?[\'"](.+?)[\'"]#', $_s, $type)){
+                                    if(!isset(self::$cmplist['type'][$type[1]])){
+                                        $delfg = true;
+                                    }
+                                }
+                                if($delfg){
+                                    $sel = preg_replace( '/(' . preg_quote($s) . ')(,|$)/u', '$2', $sel, 1 );
+                                    $_s  = '';
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if(!empty($_s)){
+                        // id / css 属性セレクタ限定の部分マッチチェック
+                        if(preg_match_all( '#\[(?<attr>class|id)(?<type>\^|\$|\*)?=["\'](?<str>[\w\-]+?)["\'].*?\]#', $_s, $smatch, PREG_SET_ORDER)){
+                            foreach ($smatch as $item) {
+                                $attr = $item['attr'];
+                                $type = $item['type'];
+                                if($type == '^'){
+                                    $str = $type . $item['str'];
+                                } elseif($type == '$'){
+                                    $str = $item['str'] . $type;
+                                } elseif($type == '*'){
+                                    $str = $item['str'];
+                                } else {
+                                    $str = '^' . $item['str'] . '$';
+                                }
+                                //属性セレクタにマッチしなければ削除　
+                                if ( ($ret = strpos(self::$cmplist[ $attr . '_str' ], $str )) === false){
+                                    $sel = preg_replace( '/(' . preg_quote($s) . ')(,|$)/u', '$2', $sel, 1 );
+                                    $_s  = '';
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                $sel = self::restore_pseudo($sel, $pseudo);
+
+                if(!empty($sel)){
+                    $sel = preg_replace('/,+/su', ',', $sel);
+                    $sel = preg_replace('/\s+/su', ' ', $sel);
+                    $sel = trim($sel);
+                    $sel = trim($sel, ',');
+                }
+                $data = (!empty($sel) && !empty($pv))? $sel . '{'. $pv .'}' : '';
+            }
+            return $data;
+        }, $css);
+        return $ncss;
+    }
+
+    //未使用変数定義の削除（tree_shaking 実行後に実施する）
+    //CSSファイルが分割されていると使われている変数定義まで削除の可能性があるので amp-custom style に限定した使用を想定
+    public static function tree_shaking4var($css) {
+        $varlist = array();
+        if(preg_match_all( "/var\((\-\-[^\s\),]+?)[\s\),]/iu", $css, $vmatches)){
+            foreach ($vmatches[1] as $v) {
+                $v = trim($v);
+                if(!isset($varlist[$v])){
+                    $varlist[$v] = 1;
+                }
+            }
+        }
+        //url() 定義時は文字列中に ; が含まれている場合あり
+        $pattern = '/(\-\-[\w\-]+?):.*?(url\([^\)]+?\).*?)?([;\}])/u';
+        $css = preg_replace_callback( $pattern, function($match) use(&$varlist) {
+            $vdef = $match[0];
+            $var  = trim($match[1]);
+            if(!isset($varlist[ $var ])){
+                $vdef = ($match[3] === '}')? '}' : '';
+            }
+            return $vdef;
+        }, $css);
+        return $css;
+    }
+
+    /*=============================================================
+     * CSS 内のコメント、改行、空白等を削除するだけのシンプルな縮小化
+     */
+    public static function simple_minify( $css ) {
+        $css = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css );
+        $css = str_replace(array("\r", "\n"), '', $css);
+        $css = str_replace("\t", ' ', $css);
+        $css = preg_replace('/\s+/su', ' ', $css);
+        $css = preg_replace('/\s([\{\}=,\)\/;>])/', '$1', $css);
+        $css = preg_replace('/([\{\}:=,\(\/!;])\s/', '$1', $css);
+        return $css;
+    }
+
+    /*=============================================================
+     * css(simple_minify済)の未使用 id, class, tag に関する定義を取り除き縮小化
+     */
+    public static function extended_minify($css, $html, $jsaddlist=array(), $varminify=false, $customcsslist=array()) {
+        self::$jsaddlist = array();
+        if(!empty($jsaddlist)){   //JS によりDOMロード後に追加される ID や class 等が除外されなくするための名前の事前登録用
+            foreach ($jsaddlist as $tag) {
+                if(!isset(self::$jsaddlist[$tag])){
+                    self::$jsaddlist[$tag] = 1;
+                }
+            }
+        }
+
+        if(empty(self::$cmplist['parse'])){
+            self::$cmplist['parse'] = true;
+            self::$cmplist['id_str'] = '';
+            self::$cmplist['class_str'] = '';
+
+			$inidata           = array(
+				'id'    => array(),
+				'class' => array(
+					'device-mobile',
+					'header_scrolled',
+					'active',
+					'menu-open',
+					'vk-mobile-nav-menu-btn',
+					'vk-mobile-nav-open',
+					'vk-menu-acc-active',
+					'acc-parent-open',
+					'acc-btn',
+					'acc-btn-open',
+					'acc-btn-close',
+					'acc-child-open',
+					'carousel-item-left',
+					'carousel-item-next',
+					'carousel-item-right',
+					'carousel-item-prev',
+					'form-control',
+					'btn',
+					'btn-primary',
+					'.vk_post_imgOuter a:hover .card-img-overlay::after',
+				),
+				'tag'   => array(
+					'html',
+					'head',
+					'body',
+					'title',
+					'style',
+					'meta',
+					'link',
+					'script',
+					'noscript',
+				),
 			);
-		}
-		return $css;
-	}
+			$inidata           = apply_filters( 'css_tree_shaking_exclude', $inidata );
 
-	// アットルール復元
-	private static function atrule_restore( $css ) {
-		$css = preg_replace_callback(
-			'|@\{(.+?)\}|',
-			function( $matches ) {
-				$data = $matches[0];
-				$key  = $matches[1];
-				if ( strpos( $key, 'AR_' ) !== false ) {
-					$data = ( ! empty( self::$atrule_data[ $key ] ) ) ? self::atrule_restore( self::$atrule_data[ $key ] ) : '';
-				}
-				return $data;
-			},
-			$css
-		);
-		return $css;
-	}
-
-	// CSS から未使用の id, class, tag を含む定義を削除
-	private static function tree_shaking( $css ) {
-		$ncss = preg_replace_callback(
-			'|(.+?)(\{.+?\})|u',
-			function( $matches ) {
-				$data = $matches[0];
-				$sel  = $matches[1];
-				if ( $sel !== '@' ) {
-					$pattern = array(
-						'id'    => '|(#)([\w\-\\%]+)|u',
-						'class' => '|(\.)([\w\-\\%]+)|u',
-						'tag'   => '/(^|[,\s>\+~\(\)\]\|])([\w\-]+)/iu',
-					);
-
-					$slist = array_map( 'trim', explode( ',', $sel ) );
-					foreach ( $slist as $s ) {
-						// selector の判定条件から :not(...) を除外 ($_s で判定して削除時は $s で行う)
-						$_s = $s;
-						if ( preg_match( '/:not\(.+?\)/', $s ) ) {
-							$_s = preg_replace( '/:not\(.+?\)/', '', $s );
-						}
-						foreach ( array( 'id', 'class', 'tag' ) as $item ) {
-							if ( ! empty( $_s ) && preg_match_all( $pattern[ $item ], $_s, $match ) ) {
-								foreach ( $match[2] as $val ) {
-									// $jsaddlist 登録名が一部でも含まれていれば削除しない（処理を簡略化するため上位層のセレクタのみで判定）
-									if ( in_array( $val, self::$jsaddlist ) ) {
-										break;
-									}
-
-									// $cmplist 登録名に含まれていないものが一つでもあれば削除
-									if ( ! preg_match( '/^[0-9]+/', $val ) && ! in_array( $val, self::$cmplist[ $item ] ) ) {
-										$sel = preg_replace( '/(' . preg_quote( $s ) . ')(,|$)/u', '$2', $sel, 1 );
-										$s   = '';
-										break;
-									}
-								}
-							}
-						}
-					}
-					$sel  = preg_replace( '/,+/su', ',', $sel );
-					$sel  = preg_replace( '/\s+/su', ' ', $sel );
-					$sel  = trim( $sel );
-					$sel  = trim( $sel, ',' );
-					$data = ( ! empty( $sel ) ) ? $sel . $matches[2] : '';
-				}
-				return $data;
-			},
-			$css
-		);
-		return $ncss;
-	}
-
-	// 未使用変数定義の削除（tree_shaking 実行後に実施する必要あり）
-	public static function tree_shaking4var( $css ) {
-		$ncss          = $css;
-		self::$varlist = array();
-		if ( preg_match_all( '/var\((\-\-.+?)\)/iu', $css, $vmatchs ) ) {
-			foreach ( $vmatchs[1] as $v ) {
-				$v = trim( $v );
-				if ( ! in_array( $v, self::$varlist ) ) {
-					self::$varlist[] = $v;
-				}
-			}
-		}
-		// url() 定義時は文字列中に ; がそのまま含まれている場合があるの分けて処理
-		$ncss = preg_replace_callback(
-			'|(\-\-[\w\-]+?):url\(.+?\);?|u',
-			function( $matches ) {
-				$data = $matches[0];
-				if ( ! in_array( trim( $matches[1] ), self::$varlist ) ) {
-					$data = '';
-				}
-				return $data;
-			},
-			$ncss
-		);
-		$ncss = preg_replace_callback(
-			'|(\-\-[\w\-]+?):(.+?)([;\}])|u',
-			function( $matches ) {
-				$data = $matches[0];
-				if ( ! preg_match( '|url\(|u', $matches[2] ) && ! in_array( trim( $matches[1] ), self::$varlist ) ) {
-					$data = ( $matches[3] === '}' ) ? '}' : '';
-				}
-				return $data;
-			},
-			$ncss
-		);
-
-		return $ncss;
-	}
-
-	/*
-	=============================================================
-	 * CSS 内のコメント、改行、空白等を削除するだけのシンプルな縮小化
-	 */
-	public static function simple_minify( $css ) {
-		$res = preg_replace( '!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css );
-		if ( ! empty( $res ) ) {
-			$css = $res;
-			$css = str_replace( array( "\r", "\n" ), '', $css );
-			$css = str_replace( "\t", ' ', $css );
-			$css = preg_replace( '/\s+/su', ' ', $css );
-			$css = preg_replace( '/\s([\{\}:=,\)*\/;>])/', '$1', $css );
-			$css = preg_replace( '/([\{\}:=,\(*\/!;>])\s/', '$1', $css );
-		}
-		return $css;
-	}
-
-	/*
-	=============================================================
-	 * CSS 内の未使用 id, class, tag に関する定義を取り除く縮小化
-	 */
-	public static function extended_minify( $css, $html, $jsaddlist = array() ) {
-		self::$atrule_data = array();
-		self::$jsaddlist   = $jsaddlist;  // JS によりDOMロード後に追加される ID や class 等が除外されなくするための名前の事前登録用
-		$inidata           = array(
-			'id'    => array(),
-			'class' => array(
-				'device-mobile',
-				'header_scrolled',
-				'active',
-				'menu-open',
-				'vk-mobile-nav-menu-btn',
-				'vk-mobile-nav-open',
-				'vk-menu-acc-active',
-				'acc-parent-open',
-				'acc-btn',
-				'acc-btn-open',
-				'acc-btn-close',
-				'acc-child-open',
-				'carousel-item-left',
-				'carousel-item-next',
-				'carousel-item-right',
-				'carousel-item-prev',
-				'form-control',
-				'btn',
-				'btn-primary',
-				'.vk_post_imgOuter a:hover .card-img-overlay::after',
-			),
-			'tag'   => array(
-				'html',
-				'head',
-				'body',
-				'title',
-				'style',
-				'meta',
-				'link',
-				'script',
-				'noscript',
-			),
-		);
-		$inidata           = apply_filters( 'css_tree_shaking_exclude', $inidata );
-		$pattern           = array(
-			'id'    => '|[\s\t\'"]id\s?=\s?[\'"](.+?)[\'"]|u',
-			'class' => '|[\s\t\'"]class\s?=\s?[\'"](.+?)[\'"]|u',
-			'tag'   => '|<([\w\-]+)|iu',
-		);
-
-		if ( empty( self::$cmplist['parse'] ) ) {
-			self::$cmplist['parse'] = true;
-			foreach ( array( 'id', 'class', 'tag' ) as $item ) {
-				self::$cmplist[ $item ] = $inidata[ $item ];
-				if ( preg_match_all( $pattern[ $item ], $html, $matches ) ) {
-					foreach ( $matches[1] as $val ) {
-						$arr = array_map( 'trim', explode( ' ', $val ) );
-						foreach ( $arr as $dt ) {
-							if ( ! empty( $dt ) && ! in_array( $dt, self::$cmplist[ $item ] ) ) {
-								self::$cmplist[ $item ][] = $dt;
-							}
-						}
-					}
-				}
-			}
-		}
-		$css = self::simple_minify( $css );
-		$css = self::atrule_store( $css );
-		$css = self::tree_shaking( $css );
-		$css = self::atrule_restore( $css );
-		// 変数のTreeshaking は必要なのに除外されてしまうので停止
-		// $css = self::tree_shaking4var( $css );
-		return $css;
-	}
+            foreach (array('id','class','tag') as $item) {
+                foreach ($inidata[$item] as $tag) {
+                    if(!isset(self::$cmplist[$item][$tag])){
+                        self::$cmplist[$item][$tag] = 1;
+                    }
+                }
+            }
+            //HTML から使用している tag, id, class 抽出
+            $pattern = '#<style(?<catrb>.*?)>.*?<\/style|<script(?<satrb>.*?)>.*?<\/script|<!--.+?-->|<(?<tag>[\w\-]+)(?<tatrb>.*?)>#si';
+            if(preg_match_all( $pattern, $html, $items, PREG_SET_ORDER)){
+                foreach ($items as $item) {
+                    $atrb = '';
+                    if(!empty($item['tag'])){
+                        if(!isset(self::$cmplist['tag'][$item['tag']])){
+                            self::$cmplist['tag'][$item['tag']] = 1;
+                        }
+                        $atrb = $item['tatrb'];
+                        //type ほぼ input のみと思われる
+                        if(preg_match('#type\s?=\s?[\'"](.+?)[\'"]#u', $atrb, $type)){
+                            if(!isset(self::$cmplist['type'][$type[1]])){
+                                self::$cmplist['type'][$type[1]] = 1;
+                            }
+                        }
+                    } elseif(!empty($item['catrb'])) {
+                        $atrb = $item['catrb'];
+                    } elseif(!empty($item['satrb'])) {
+                        $atrb = $item['satrb'];
+                    }
+                    $atrb = trim($atrb);
+                    if(!empty($atrb)){
+                        if(preg_match('#id\s?=\s?[\'"](.+?)[\'"]#u', $atrb, $id)){
+                            $arr = array_map("trim", explode(' ', $id[1]));
+                            foreach($arr as $id){
+                                $id = trim($id);
+                                if(!isset(self::$cmplist['id'][$id])){
+                                    self::$cmplist['id'][$id] = 1;
+                                    self::$cmplist['id_str'] .= '^' . $id . '$';
+                                }
+                            }
+                        }
+                        if(preg_match('#class\s?=\s?[\'"](.+?)[\'"]#u', $atrb, $cls)){
+                            $arr = array_map("trim", explode(' ', $cls[1]));
+                            foreach($arr as $cls){
+                                $cls = trim($cls);
+                                if(!isset(self::$cmplist['class'][$cls])){
+                                    self::$cmplist['class'][$cls] = 1;
+                                    self::$cmplist['class_str'] .= '^' . $cls . '$';
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        $css = self::tree_shaking( $css, $customcsslist );
+        if($varminify){
+            $css = self::tree_shaking4var( $css );
+        }
+        return $css;
+    }
 }

--- a/vk-css-optimize/package/class-vk-css-optimize.php
+++ b/vk-css-optimize/package/class-vk-css-optimize.php
@@ -316,12 +316,12 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 			$vk_css_tree_shaking_array  = self::css_tree_shaking_array();
 			$vk_css_simple_minify_array = self::css_simple_minify_array();
 
+			// WP_Filesystem() が使えるように読み込み.
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+
 			// CSS Tree Shaking //////////////////////////////////////////// .
 
 			foreach ( $vk_css_tree_shaking_array as $vk_css_array ) {
-
-				// WP File System で CSS ファイルを読み込み.
-				require_once ABSPATH . 'wp-admin/includes/file.php';
 
 				// 読み込むCSSファイルのパス.
 				$path_name = $vk_css_array['path'];
@@ -354,8 +354,6 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 
 			foreach ( $vk_css_simple_minify_array as $vk_css_array ) {
 
-				// WP File System で CSS ファイルを読み込み
-				require_once ABSPATH . 'wp-admin/includes/file.php';
 				$path_name = $vk_css_array['path'];
 				if ( WP_Filesystem() ) {
 					global $wp_filesystem;

--- a/vk-css-optimize/package/class-vk-css-optimize.php
+++ b/vk-css-optimize/package/class-vk-css-optimize.php
@@ -332,7 +332,7 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 				}
 
 				// ree shaking を実行して再格納 .
-				$css    = celtislab\v2_1\CSS_tree_shaking::extended_minify( celtislab\v2_1\CSS_tree_shaking::simple_minify( $css ), $buffer );
+				$css = celtislab\v2_1\CSS_tree_shaking::extended_minify( celtislab\v2_1\CSS_tree_shaking::simple_minify( $css ), $buffer );
 
 				// ファイルで読み込んでいるCSSを直接出力に置換（バージョンパラメーターあり）.
 				$buffer = str_replace(
@@ -362,11 +362,13 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 
 				$css = celtislab\v2_1\CSS_tree_shaking::simple_minify( $css );
 
+				// ファイルで読み込んでいるCSSを直接出力に置換（バージョンパラメーターあり）.
 				$buffer = str_replace(
 					'<link rel=\'stylesheet\' id=\'' . $vk_css_array['id'] . '-css\'  href=\'' . $vk_css_array['url'] . '?ver=' . $vk_css_array['version'] . '\' type=\'text/css\' media=\'all\' />',
 					'<style id=\'' . $vk_css_array['id'] . '-css\' type=\'text/css\'>' . $css . '</style>',
 					$buffer
 				);
+				// ファイルで読み込んでいるCSSを直接出力に置換（バージョンパラメーターなし）.
 				$buffer = str_replace(
 					'<link rel=\'stylesheet\' id=\'' . $vk_css_array['id'] . '-css\'  href=\'' . $vk_css_array['url'] . '\' type=\'text/css\' media=\'all\' />',
 					'<style id=\'' . $vk_css_array['id'] . '-css\' type=\'text/css\'>' . $css . '</style>',
@@ -381,11 +383,11 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 		/**
 		 * Undocumented function
 		 *
-		 * @param [type] $tag
-		 * @param [type] $handle
-		 * @param [type] $href
-		 * @param [type] $media
-		 * @return void
+		 * @param string $tag .
+		 * @param string $handle .
+		 * @param string $href .
+		 * @param string $media .
+		 * @return string $tag .
 		 */
 		public static function css_preload( $tag, $handle, $href, $media ) {
 
@@ -397,25 +399,30 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 			$options = self::get_css_optimize_options();
 
 			// tree shaking がかかっているものはpreloadから除外する
-			// でないと表示時に一瞬崩れて結局実用性に問題があるため
+			// でないと表示時に一瞬崩れて結局実用性に問題があるため.
 			foreach ( $vk_css_tree_shaking_array as $vk_css_array ) {
 				$exclude_handles[] = $vk_css_array['id'];
 			}
 
 			// Simple Minify がかかっているものはpreloadから除外する
-			// でないと表示時に一瞬崩れて結局実用性に問題があるため
+			// でないと表示時に一瞬崩れて結局実用性に問題があるため.
 			foreach ( $vk_css_simple_minify_array as $vk_css_array ) {
 				$exclude_handles[] = $vk_css_array['id'];
 			}
 
+			// プリロードから除外するCSSハンドルが option で保存されている場合.
 			if ( ! empty( $options['preload_handle_exclude'] ) ) {
-				$exclude_array   = explode( ',', $options['preload_handle_exclude'] );
+				// 保存されているされている除外するCSSハンドルを配列に変換.
+				$exclude_array = explode( ',', $options['preload_handle_exclude'] );
+				// 除外するCSSハンドルの配列をマージ.
 				$exclude_handles = array_merge( $exclude_array, $exclude_handles );
 			}
 
 			$exclude_handles = apply_filters( 'vk_css_preload_exclude_handles', $exclude_handles );
-			// クリティカルじゃないCSS（tree shakingにかけているもの以外）をpreload
+
+			// クリティカルじゃないCSS（tree shakingにかけているもの以外）をpreload .
 			if ( ! in_array( $handle, $exclude_handles ) ) {
+				// preload を追加する.
 				$tag  = "<link rel='preload' id='" . $handle . "-css' href='" . $href . "' as='style' onload=\"this.onload=null;this.rel='stylesheet'\"/>\n";
 				$tag .= "<link rel='stylesheet' id='" . $handle . "-css' href='" . $href . "' media='print' onload=\"this.media='all'; this.onload=null;\">\n";
 			}

--- a/vk-css-optimize/package/class-vk-css-optimize.php
+++ b/vk-css-optimize/package/class-vk-css-optimize.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * VK CSS Optimize
- * 
+ *
  * @package VK CSS Optimize
  */
 
@@ -27,8 +27,7 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 			$options = self::get_css_optimize_options();
 
 			if ( ! empty( $options['tree_shaking'] ) ) {
-				add_action( 'get_header', array( __CLASS__, 'get_html_start' ), 2147483647 );
-				add_action( 'shutdown', array( __CLASS__, 'get_html_end' ), 0 );
+				add_filter('wp_using_themes', array(__CLASS__, 'get_html_start'), 1, 1);
 			}
 
 			if ( ! empty( $options['preload'] ) ) {
@@ -256,17 +255,11 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 		/**
 		 * Get HTML Document Start
 		 */
-		public static function get_html_start() {
-			ob_start( 'VK_CSS_Optimize::css_tree_shaking_buffer' );
-		}
-
-		/**
-		 * Get HTML Document End
-		 */
-		public static function get_html_end() {
-			if ( ob_get_length() ) {
-				ob_end_flush();
+		public static function get_html_start($is_use_themes) {
+			if ($is_use_themes && did_action('template_redirect') === 0 ) {
+				ob_start( 'VK_CSS_Optimize::css_tree_shaking_buffer' );
 			}
+			return $is_use_themes;
 		}
 
 		/**
@@ -314,7 +307,7 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 					$css = $wp_filesystem->get_contents( $path_name );
 				}
 
-				$css    = celtislab\CSS_tree_shaking::extended_minify( $css, $buffer );
+				$css    = celtislab\v2_1\CSS_tree_shaking::extended_minify( celtislab\v2_1\CSS_tree_shaking::simple_minify( $css ), $buffer );
 				$buffer = str_replace(
 					'<link rel=\'stylesheet\' id=\'' . $vk_css_array['id'] . '-css\'  href=\'' . $vk_css_array['url'] . '?ver=' . $vk_css_array['version'] . '\' type=\'text/css\' media=\'all\' />',
 					'<style id=\'' . $vk_css_array['id'] . '-css\' type=\'text/css\'>' . $css . '</style>',
@@ -339,7 +332,7 @@ if ( ! class_exists( 'VK_CSS_Optimize' ) ) {
 					$css = $wp_filesystem->get_contents( $path_name );
 				}
 
-				$css = celtislab\CSS_tree_shaking::simple_minify( $css );
+				$css = celtislab\v2_1\CSS_tree_shaking::simple_minify( $css );
 
 				$buffer = str_replace(
 					'<link rel=\'stylesheet\' id=\'' . $vk_css_array['id'] . '-css\'  href=\'' . $vk_css_array['url'] . '?ver=' . $vk_css_array['version'] . '\' type=\'text/css\' media=\'all\' />',


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/lightning/issues/851

## どういう変更をしたか？

- Tree Shaking を更新しそれに合わせた構築に変更しました。
- 参考ソース：[YASAKANI Cache](https://ja.wordpress.org/plugins/yasakani-cache/)


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

1. VK Blocks Pro にこのモジュールを適用
1.  VK Blocks Pro と Lightning のみ有効化 ( ExUnit は無効化した状態 )
1. 見出し/装飾無し/中央寄せ の core/heading ブロックを設置
1. 新たに 任意の設定の core/heading ブロックを設置
1. 公開画面で両方のスタイルがあたっていることを確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

1. VK Blocks Pro にこのモジュールを適用
1.  VK Blocks Pro と Lightning のみ有効化 ( ExUnit は無効化した状態 )
1. 見出し/装飾無し/中央寄せ の core/heading ブロックを設置
1. 新たに 任意の設定の core/heading ブロックを設置
1. 公開画面で両方のスタイルがあたっていることを確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
