### PR TITLE
[ 固定ナビ ] クリックイベントの例で書かれているコードがUA形式からGA4形式修正

### DIFF
--- a/vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php
+++ b/vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php
@@ -455,7 +455,7 @@ if ( ! class_exists( 'Vk_Mobile_Fix_Nav' ) ) {
 						'section'     => 'vk_mobil_fix_nav_setting',
 						'settings'    => 'vk_mobil_fix_nav_options[event_' . $i . ']',
 						'type'        => 'text',
-						'description' => __( 'Ex', 'vk_mobile_fix_nav_textdomain' ) . " ) ga('send', 'event', 'Videos', 'play', 'Fall Campaign');",
+						'description' => __( 'Ex', 'vk_mobile_fix_nav_textdomain' ) . " ) gtag('event', 'play', { 'event_category': 'Videos', 'event_label': 'Fall Campaign'});",
 					)
 				);
 


### PR DESCRIPTION
#141

機能的な部分ではなく、
> 例）ga('send', 'event', 'Videos', 'play', 'Fall Campaign')

の例で書かれているコードがUA形式で現在のGA4形式ではなかったので  `gtag('event', 'play', { 'event_category': 'Videos', 'event_label': 'Fall Campaign'})` に修正しました。

自サーバーで上記のコードを設定したところ、GA4で計測されました。

![スクリーンショット 2024-10-17 12 05 34](https://github.com/user-attachments/assets/be0b4be6-ee7d-4052-8166-c7e22dbeb054)
![スクリーンショット 2024-10-17 12 05 03](https://github.com/user-attachments/assets/0fa0836e-611e-4128-96b3-5484596953ba)
![スクリーンショット 2024-10-17 12 05 12](https://github.com/user-attachments/assets/5141188f-4895-4531-9b7f-b6ddcd2e10a1)
![スクリーンショット 2024-10-17 12 05 21](https://github.com/user-attachments/assets/0a351327-10fb-4b32-b753-0f3705d487a4)