### PR TITLE
[ その他 ][ 7.0 対応 ] メタボックスにRTC互換フラグを追加

### DIFF
--- a/custom-field-builder/class-flexible-table-sample.php
+++ b/custom-field-builder/class-flexible-table-sample.php
@@ -33,7 +33,7 @@ class Flexible_Table_Sample {
 		$screen        = 'vk-managing-patterns';
 		$context       = 'advanced';
 		$priority      = 'high';
-		$callback_args = '';
+		$callback_args = array( '__back_compat_meta_box' => true );
 
 		add_meta_box( $id, $title, $callback, $screen, $context, $priority, $callback_args );
 

--- a/post-type-manager/package/class.post-type-manager.php
+++ b/post-type-manager/package/class.post-type-manager.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		 * カスタムフィールドの meta box を作成.
 		 */
 		public static function add_meta_box() {
-			add_meta_box( 'meta_box_post_type_manage', __( 'Custom Post Type Setting', 'vk_post_type_manager_textdomain' ), array( __CLASS__, 'add_meta_box_action' ), 'post_type_manage', 'normal', 'high' );
+			add_meta_box( 'meta_box_post_type_manage', __( 'Custom Post Type Setting', 'vk_post_type_manager_textdomain' ), array( __CLASS__, 'add_meta_box_action' ), 'post_type_manage', 'normal', 'high', array( '__back_compat_meta_box' => true ) );
 		}
 
 		/**

--- a/vk-page-header/package/class-vk-page-header.php
+++ b/vk-page-header/package/class-vk-page-header.php
@@ -732,7 +732,7 @@ if ( ! class_exists( 'Vk_Page_Header' ) ) {
 			if ( isset( $_GET['post'] ) && $_GET['post'] === get_option( 'page_for_posts' ) && 'page' === get_option( 'show_on_front' ) ) {
 				return;
 			}
-			add_meta_box( 'vk_page_header_meta_box', __( 'Page Header Image', 'vk_page_header_textdomain' ), array( $this, 'vk_page_header_meta_box_content' ), 'page', 'normal', 'high' );
+			add_meta_box( 'vk_page_header_meta_box', __( 'Page Header Image', 'vk_page_header_textdomain' ), array( $this, 'vk_page_header_meta_box_content' ), 'page', 'normal', 'high', array( '__back_compat_meta_box' => true ) );
 		}
 
 		public function vk_page_header_meta_box_content() {


### PR DESCRIPTION
## 概要

WordPress 7.0 で導入される Real-Time Collaboration (RTC) に対応するため、既存の `add_meta_box()` 呼び出しに `__back_compat_meta_box` フラグを追加しました。

## 変更内容

以下の3箇所の `add_meta_box()` に `array( '__back_compat_meta_box' => true )` を `$callback_args` として追加:

- **post-type-manager**: `class.post-type-manager.php` - Custom Post Type Setting メタボックス
- **vk-page-header**: `class-vk-page-header.php` - Page Header Image メタボックス
- **custom-field-builder**: `class-flexible-table-sample.php` - blockTypes メタボックス

### テスト手順

#### 前提条件
- WordPress Beta Tester プラグインで **WordPress 7.0 RC** にアップデートしていること
- Vektor WP Libraries（※ライブラリのため、利用先テーマ/プラグインで確認） が有効化されていること
- 上記以外のプラグインを一時的に停止すること
- 管理者アカウントが2つあること

#### RTC 動作確認（WordPress 7.0 RC）

1. 管理画面 > 設定 > 投稿設定 で「Collaboration」を有効にする
2. User1 で投稿（または固定ページ）の編集画面を開く
   → ✓ カスタム投稿タイプ設定メタボックスが正常に表示される（post-type-manager 利用先）
   → ✓ ページヘッダー画像メタボックスが正常に表示される（vk-page-header 利用先）
   → ✓ ブロックタイプ設定メタボックスが正常に表示される（custom-field-builder 利用先）
3. User2 で別のブラウザ（またはシークレットウィンドウ）から同じ投稿を開く
   → ✓ RTC が有効になっている（右上にアバターが2つ表示される）
   → ✓ メタボックスが存在していても RTC がブロックされていないこと
4. User1 がタイトルや本文を変更する
   → ✓ User2 側にリアルタイムで反映されること

#### デグレ確認（WordPress 6.x）
1. WordPress Beta Tester プラグインで 6.x に戻す（または別環境で確認）
2. 投稿編集画面を開く
   → ✓ カスタム投稿タイプ設定メタボックスが正常に表示される（post-type-manager 利用先）
   → ✓ ページヘッダー画像メタボックスが正常に表示される（vk-page-header 利用先）
   → ✓ ブロックタイプ設定メタボックスが正常に表示される（custom-field-builder 利用先）
3. メタボックスで設定を変更し保存する
   → ✓ 設定が正常に保存される（既存動作に影響なし）

### レビューポイント（任意）
- 各 `add_meta_box()` の第7引数に `array( '__back_compat_meta_box' => true )` が正しく追加されているか
- 既存の引数が変更されていないか

### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している（必要な場合）
- [ ] 正しいディレクトリで作業している
- [ ] キャッシュをクリアしている

関連Issue: #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * メタボックス登録機能が複数のモジュール全体で更新され、以前のバージョンとの互換性がより確実に保証されるようになりました。この変更により、既存の設定環境での安定した動作が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
