### PR TITLE
【調整中】[ 7.0 対応 ] __back_compat_meta_box の値を修正

### DIFF
--- a/custom-field-builder/class-flexible-table-sample.php
+++ b/custom-field-builder/class-flexible-table-sample.php
@@ -33,7 +33,7 @@ class Flexible_Table_Sample {
 		$screen        = 'vk-managing-patterns';
 		$context       = 'advanced';
 		$priority      = 'high';
-		$callback_args = array( '__back_compat_meta_box' => true );
+		$callback_args = array( '__back_compat_meta_box' => false );
 
 		add_meta_box( $id, $title, $callback, $screen, $context, $priority, $callback_args );
 

--- a/post-type-manager/package/class.post-type-manager.php
+++ b/post-type-manager/package/class.post-type-manager.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'VK_Post_Type_Manager' ) ) {
 		 * カスタムフィールドの meta box を作成.
 		 */
 		public static function add_meta_box() {
-			add_meta_box( 'meta_box_post_type_manage', __( 'Custom Post Type Setting', 'vk_post_type_manager_textdomain' ), array( __CLASS__, 'add_meta_box_action' ), 'post_type_manage', 'normal', 'high', array( '__back_compat_meta_box' => true ) );
+			add_meta_box( 'meta_box_post_type_manage', __( 'Custom Post Type Setting', 'vk_post_type_manager_textdomain' ), array( __CLASS__, 'add_meta_box_action' ), 'post_type_manage', 'normal', 'high', array( '__back_compat_meta_box' => false ) );
 		}
 
 		/**

--- a/vk-page-header/package/class-vk-page-header.php
+++ b/vk-page-header/package/class-vk-page-header.php
@@ -732,7 +732,7 @@ if ( ! class_exists( 'Vk_Page_Header' ) ) {
 			if ( isset( $_GET['post'] ) && $_GET['post'] === get_option( 'page_for_posts' ) && 'page' === get_option( 'show_on_front' ) ) {
 				return;
 			}
-			add_meta_box( 'vk_page_header_meta_box', __( 'Page Header Image', 'vk_page_header_textdomain' ), array( $this, 'vk_page_header_meta_box_content' ), 'page', 'normal', 'high', array( '__back_compat_meta_box' => true ) );
+			add_meta_box( 'vk_page_header_meta_box', __( 'Page Header Image', 'vk_page_header_textdomain' ), array( $this, 'vk_page_header_meta_box_content' ), 'page', 'normal', 'high', array( '__back_compat_meta_box' => false ) );
 		}
 
 		public function vk_page_header_meta_box_content() {


### PR DESCRIPTION
## 変更の理由

PR #157 で `__back_compat_meta_box => true` が追加されましたが、この値は「ブロックエディタ側に代替UIがある」ことを意味し、ブロックエディタでメタボックスが非表示になります。

このライブラリのメタボックスにはブロックエディタの代替UIがないため、`false` が正しい値です。

## 変更内容

3ファイルの `__back_compat_meta_box` を `true` → `false` に修正：

* `custom-field-builder/class-flexible-table-sample.php`
* `vk-page-header/package/class-vk-page-header.php`
* `post-type-manager/package/class.post-type-manager.php`

## 確認手順

このライブラリは単体では動作しないため、利用先のテーマ（Lightning、Katawara 等）をインストールした環境で確認してください。

### 前提条件
- Lightning テーマ（または Katawara 等、本ライブラリを利用するテーマ）が有効化されていること

### Before（修正前 / master ブランチ）
1. テーマが参照する vektor-wp-libraries が master ブランチの状態であることを確認する
   - テーマの `composer.json` で vektor-wp-libraries のバージョンが通常のリリース版（例: `^2.0`）になっていることを確認し、`composer update vektor-inc/vektor-wp-libraries` を実行
2. ブロックエディタで投稿編集画面を開く
   → ✗ ページヘッダー画像・投稿タイプマネージャー等のメタボックスが表示されない（`true` フラグにより非表示）
3. クラシックエディタで同じ投稿を開き、各メタボックスで値を設定して保存する

### After（修正後 / feature ブランチ）
1. テーマが参照する vektor-wp-libraries を本ブランチに差し替える
   1. テーマの `composer.json` を開き、vektor-wp-libraries の参照先を本ブランチに変更する
      ```json
      "vektor-inc/vektor-wp-libraries": "dev-fix/back-compat-meta-box-value"
      ```
   2. `composer update vektor-inc/vektor-wp-libraries` を実行する
   3. テーマの `vendor/vektor-inc/vektor-wp-libraries/` 内のファイルが本ブランチの内容に更新されたことを確認する
2. 同じ投稿をブロックエディタで開く
   → ✓ メタボックスが正常に表示される（`false` に修正されたため）
   → ✓ Before でクラシックエディタから設定した値が正しく表示される
3. 設定を変更して保存 → 再読み込み
   → ✓ 変更後の値が正しく保存・反映される
4. クラシックエディタでも確認する
   → ✓ 従来通り表示・動作する

関連Issue: #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * 複数のメタボックスの後方互換性設定を更新しました。内部動作の一貫性を改善するため、管理画面のメタボックス登録設定を調整いたしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





