### PR TITLE
[ その他 ][ CF Builder ] テーブルのサンプルコードである旨をコメント・READMEに明記

### DIFF
--- a/custom-field-builder/class-flexible-table-sample.php
+++ b/custom-field-builder/class-flexible-table-sample.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Custom Field Builder の利用サンプル
+ *
+ * このファイルは Custom Field Builder（custom-field-builder/）の使い方を示す
+ * サンプルコードです。ライブラリ本体や config からは読み込まれません。
+ * カスタムフィールドを追加する際の記述例として参照してください。
+ *
+ * @package vektor-wp-libraries
+ */
 class Flexible_Table_Sample {
 
 	public static $custom_fields_array = array(

--- a/custom-field-builder/readme.md
+++ b/custom-field-builder/readme.md
@@ -3,3 +3,7 @@
 1. custom-field-builder-config.php を Custom Field Builder を使用するプラグインディレクトリ（incなど）に複製
 1. custom-field-builder-config.php の中身をプラグインの情報にあわせて書き換える
 1. プラグインが最初に読み込むPHPファイルなどから require_once( 'inc/custom-field-builder-config.php' ); などで読み込む
+
+## サンプルコードについて
+
+`class-flexible-table-sample.php` は、フィールド定義からフォーム表示・保存までの一連の記述例を示す**サンプルコード**です。ライブラリ本体や config からは読み込まれません。実装の参考としてご利用ください。


### PR DESCRIPTION
## 概要

`custom-field-builder/class-flexible-table-sample.php` が、Custom Field Builder の使い方を示す**サンプルコード**であることを、ファイル冒頭コメントと `custom-field-builder/readme.md` に明記しました。

#160 で「このファイルはどこからも require されておらず不要では？」と相談したところ、作者の @kurudrive さんより「意図的に残しているサンプルコードです」との回答をいただきました。今後同じ疑問が生まれないよう、サンプルである旨を明示する変更です。

ロジックの変更は一切なく、ドキュメント注記の追加のみです。

## 変更内容

- `class-flexible-table-sample.php` の冒頭に、サンプルコードであり本体や config から読み込まれない旨の docblock コメントを追加
- `custom-field-builder/readme.md` に「サンプルコードについて」の節を追加

## 確認手順

1. `custom-field-builder/class-flexible-table-sample.php` を開く
   → 冒頭にサンプルコードである旨の説明コメントが表示される
2. `custom-field-builder/readme.md` を開く
   → 末尾に「## サンプルコードについて」の節があり、当該ファイルがサンプルである旨が記載されている
3. PHP の実行内容は変更していないため、既存の動作に影響がないこと（注記追加のみ）を `git diff` で確認

## 関連Issue

関連Issue: #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Custom Field Builder（Flexible Table）の実装例を示すサンプルコードを追加しました。フィールド定義からフォーム表示、データ保存までの全体的な流れを参考にできます。

* **ドキュメント**
  * サンプルコードの説明をドキュメントに追記し、参考実装として利用できることを明記しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vektor-wp-libraries/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->