### PR TITLE
[ 不具合修正 ][ vk-mobile-fix-nav ] アセットバージョン 0.0.0 固定でCSSキャッシュが自動更新されない不具合を修正

### DIFF
--- a/vk-google-tag-manager/package/class-vk-google-tag-manager.php
+++ b/vk-google-tag-manager/package/class-vk-google-tag-manager.php
@@ -19,9 +19,6 @@ if ( ! class_exists( 'Vk_Goole_Tag_Manager' ) ) {
 
 	class Vk_Goole_Tag_Manager {
 
-
-		public static $version = '0.0.0';
-
 		/*-------------------------------------------*/
 		/*	Customizer
 		/*-------------------------------------------*/

--- a/vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php
+++ b/vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php
@@ -580,9 +580,20 @@ if ( ! class_exists( 'Vk_Mobile_Fix_Nav' ) ) {
 			return $css_url;
 		}
 
+		/**
+		 * フロント用CSSを読み込む。
+		 *
+		 * アセットのバージョンにCSSファイルの更新時刻（filemtime）を使うことで、
+		 * CSSを更新した際にブラウザキャッシュが自動で更新されるようにする。
+		 *
+		 * @return void
+		 */
 		static function add_style() {
-			$css_url = self::style_url();
-			wp_enqueue_style( 'vk-mobile-fix-nav', $css_url, array(), self::$version, 'all' );
+			$css_url  = self::style_url();
+			$css_path = wp_normalize_path( dirname( __FILE__ ) ) . '/css/vk-mobile-fix-nav.css';
+			// ファイルが存在すれば更新時刻を、存在しなければ従来のバージョン定数をフォールバックとして使う。
+			$css_version = file_exists( $css_path ) ? filemtime( $css_path ) : self::$version;
+			wp_enqueue_style( 'vk-mobile-fix-nav', $css_url, array(), $css_version, 'all' );
 		}
 
 		public static function css_tree_shaking_handles( $vk_css_tree_shaking_handles ) {

--- a/vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php
+++ b/vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php
@@ -591,8 +591,9 @@ if ( ! class_exists( 'Vk_Mobile_Fix_Nav' ) ) {
 		static function add_style() {
 			$css_url  = self::style_url();
 			$css_path = wp_normalize_path( dirname( __FILE__ ) ) . '/css/vk-mobile-fix-nav.css';
-			// ファイルが存在すれば更新時刻を、存在しなければ従来のバージョン定数をフォールバックとして使う。
-			$css_version = file_exists( $css_path ) ? filemtime( $css_path ) : self::$version;
+			// ファイルの更新時刻を取得する。取得できなければ（存在しない・取得失敗）従来のバージョン定数をフォールバックとして使う。
+			$css_mtime   = file_exists( $css_path ) ? filemtime( $css_path ) : false;
+			$css_version = ( false !== $css_mtime ) ? $css_mtime : self::$version;
 			wp_enqueue_style( 'vk-mobile-fix-nav', $css_url, array(), $css_version, 'all' );
 		}
 


### PR DESCRIPTION
## 概要

共有ライブラリ vk-mobile-fix-nav（スマホ表示時に画面下部へ固定表示するナビゲーション）のフロント用CSSの読み込みで、アセットのバージョン指定（`wp_enqueue_style()`（CSS読み込み関数）の `$ver` 引数）が `0.0.0` に固定されていました。このためCSSファイルを更新してもブラウザキャッシュが自動で更新されず、古い見た目が残り続ける不具合がありました。

このPRでは、配布元であるこのリポジトリを対象に、アセットのバージョンを **CSSファイルの更新時刻（`filemtime()`（ファイル更新時刻を取得する関数））** ベースへ変更し、CSSを更新すればキャッシュが自動で切り替わるようにします。同リポジトリの vk-page-header に同じ方式の前例があります。

関連Issue: #166
関連（同梱先の親Issue）: vektor-inc/lightning-pro#377

## 変更内容

- **vk-mobile-fix-nav**（`vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php`）
  - `add_style()`（CSS読み込み処理）のバージョン指定を `self::$version`（`0.0.0` 固定）から、CSSファイルの `filemtime()`（更新時刻）へ変更。
  - ファイルが存在しない環境に備え、`file_exists()`（ファイル存在確認）で守り、欠落時は従来の `$version`（バージョン定数）へフォールバック（後方互換）。`$version` プロパティ自体はフォールバック用に残置。
- **vk-google-tag-manager**（`vk-google-tag-manager/package/class-vk-google-tag-manager.php`）
  - 宣言だけで参照されていない未使用プロパティ `public static $version`（バージョン変数）を削除（アセット読み込みが無くキャッシュ問題は起きないが、ライブラリを触る機会に掃除）。

## スコープ（今回やること / やらないこと）

- **やること**: 配布元 vektor-wp-libraries のソース修正のみ。
- **やらないこと（follow-up）**: 同梱先（lightning-pro / katawara / lightning-g3-pro-unit / vk-mobile-nav）はコミット済みのコピーを持つため、**この修正が master に入ったあとに各プロダクトへ再同期** します（別対応）。エンドユーザー向けの changelog は同梱先の再同期PR側で記載します（本リポジトリには changelog セクションが無いため本PRでは追記なし）。

## テスト（確認手順）

このリポジトリは共有ライブラリのソース（gulp でのビルド用）で単体の実行環境を持たないため、確認は「コードの効果」と「同梱環境での目視」の2段構えです。

### コードレベルの確認（環境不要）

1. `filemtime()` が対象CSS（`vk-mobile-fix-nav/package/css/vk-mobile-fix-nav.css`）に対して数値（Unixタイムスタンプ）を返すこと。
   → 実測: `1784171232` を返すことを確認済み。
2. 変更した2ファイルの構文チェック（`php -l`）が通ること。
   → 実測: いずれも `No syntax errors detected`。

### 同梱環境での目視確認（Before / After）

vk-mobile-fix-nav を読み込むテーマ・プロダクトを有効化したWordPress環境で確認します。

- **Before（修正前）**: フロントページのソースを表示し、`vk-mobile-fix-nav.css` の `<link>` タグを探すと、URL 末尾が `?ver=0.0.0` になっている。CSSを更新しても `ver` が変わらず、ブラウザキャッシュが残る。
- **After（修正後）**: 同じ `<link>` タグの URL 末尾が `?ver=<数字のタイムスタンプ>`（例: `?ver=1784171232`）になっている。CSSファイルを更新（保存）して再読み込みすると、`ver` の数値が新しい更新時刻に変わり、キャッシュが自動で切り替わる。

### スクリーンショット

表示（レイアウト・色・余白など）は変わらず、変わるのはアセットURLの `?ver=` の値のみのため、Before/After スクリーンショットは省略します。

### PHPUnit

本リポジトリにはテスト環境（`tests/` ・phpunit 設定）が無く、変更も `wp_enqueue_style()` によるアセット読み込み（フックまわり）のため、単体テストは作成していません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * モバイル向けナビゲーションのCSS読み込み時に、CSSファイルの更新日時を反映したバージョン付与に変更され、反映がより確実になりました。  
  * ファイル更新時にブラウザーキャッシュに古いCSSが残りにくくなり、変更が表示されない問題の軽減につながります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->