### PR TITLE
[ 不具合修正 ][ vk-mobile-fix-nav ] アセットバージョン未更新でCSS変更が反映されない不具合を修正

### DIFF
--- a/.github/workflows/vk-mobile-fix-nav-version-guard.yml
+++ b/.github/workflows/vk-mobile-fix-nav-version-guard.yml
@@ -1,0 +1,29 @@
+name: vk-mobile-fix-nav version guard
+
+on:
+  pull_request:
+    paths:
+      - 'vk-mobile-fix-nav/package/css/**'
+      - 'vk-mobile-fix-nav/package/_scss/**'
+
+permissions:
+  contents: read
+
+jobs:
+  version-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: vk-mobile-fix-nav のバージョン更新を確認する
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          CLASS_FILE="vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php"
+          if git diff "$BASE_SHA" HEAD -- "$CLASS_FILE" | grep -qE '^\+[[:space:]]*public static \$version'; then
+            echo "OK: \$version が更新されています。"
+          else
+            echo "::error file=$CLASS_FILE::vk-mobile-fix-nav の CSS/SCSS を変更した場合は $CLASS_FILE の \$version を必ず更新してください（フロントCSSのキャッシュバスター用）。"
+            exit 1
+          fi

--- a/.github/workflows/vk-mobile-fix-nav-version-guard.yml
+++ b/.github/workflows/vk-mobile-fix-nav-version-guard.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: vk-mobile-fix-nav のバージョン更新を確認する
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php
+++ b/vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'Vk_Mobile_Fix_Nav' ) ) {
 
 	class Vk_Mobile_Fix_Nav {
 
-		public static $version = '0.0.0';
+		public static $version = '0.1.0';
 
 		public function __construct() {
 
@@ -583,18 +583,15 @@ if ( ! class_exists( 'Vk_Mobile_Fix_Nav' ) ) {
 		/**
 		 * フロント用CSSを読み込む。
 		 *
-		 * アセットのバージョンにCSSファイルの更新時刻（filemtime）を使うことで、
-		 * CSSを更新した際にブラウザキャッシュが自動で更新されるようにする。
+		 * アセットのバージョンにモジュールのバージョン（self::$version）を使うことで、
+		 * CSSを更新した際は $version を上げればブラウザキャッシュが更新される。
+		 * $version の上げ忘れは CI（version guard）で検知する。
 		 *
 		 * @return void
 		 */
 		static function add_style() {
-			$css_url  = self::style_url();
-			$css_path = wp_normalize_path( dirname( __FILE__ ) ) . '/css/vk-mobile-fix-nav.css';
-			// ファイルの更新時刻を取得する。取得できなければ（存在しない・取得失敗）従来のバージョン定数をフォールバックとして使う。
-			$css_mtime   = file_exists( $css_path ) ? filemtime( $css_path ) : false;
-			$css_version = ( false !== $css_mtime ) ? $css_mtime : self::$version;
-			wp_enqueue_style( 'vk-mobile-fix-nav', $css_url, array(), $css_version, 'all' );
+			$css_url = self::style_url();
+			wp_enqueue_style( 'vk-mobile-fix-nav', $css_url, array(), self::$version, 'all' );
 		}
 
 		public static function css_tree_shaking_handles( $vk_css_tree_shaking_handles ) {


### PR DESCRIPTION
## 概要

共有ライブラリ vk-mobile-fix-nav（スマホ画面下部に固定表示するフッターナビ）のフロント用 CSS のキャッシュバスター（ブラウザキャッシュを更新させる仕組み）を、`filemtime()`（ファイル更新時刻）方式から **モジュール自身のバージョン番号（`self::$version`）方式（`?ver=X.X.X`）** へ差し替えます。あわせて、CSS を変更したのにバージョンを上げ忘れた PR を CI で弾く番人を追加します。

方式決定の経緯・却下案・実害の裏取りは 関連Issue #166 のコメント（方式変更の記録）に残しています。

## 背景

- `wp_enqueue_style()`（CSS 読み込み関数）に渡すバージョンが長らく `0.0.0` 固定で、**CSS を更新してもブラウザキャッシュが自動更新されない**不具合がありました（#166）。実際、この module の SCSS は約25回・生成 CSS は約20回変更されている一方 `$version` は `0.0.0` のままで、過去の CSS 更新はいずれも `?ver=0.0.0` のまま配信されていました。
- 先行の #167 は `filemtime()`（ファイル更新時刻）方式で対応済み（マージ済み）ですが、共有ライブラリは composer 依存ではなく**コミット済みコピー**として各プロダクトへ配布されるため、`git checkout` / rsync などでファイル更新時刻がリセットされ、**CSS 未変更でも再デプロイのたびにキャッシュが無駄に破棄される・複数サーバー間で値が食い違う**という副作用が起きやすい方式でした。
- そこで、ライブラリ内の他モジュール（vk-mobile-nav `0.3.3` / vk-page-header `0.1.2` / vk-admin `2.6.0` など）と同じ **セマンティックバージョン方式** に揃え、かつ「手動バージョンの上げ忘れ（＝再発）」を CI で機械的に防ぐ構成にします。

## 変更内容

1. `vk-mobile-fix-nav/package/class-vk-mobile-fix-nav.php`
   - `add_style()`（フロント CSS 読み込み処理）のバージョン引数を `filemtime()` から `self::$version` へ差し戻し。
   - `public static $version` を `0.0.0` → **`0.1.0`** に設定（初めて正式に版管理する起点。0.x ファミリーの他モジュールに合わせた値）。
2. `.github/workflows/vk-mobile-fix-nav-version-guard.yml`（新規）
   - `vk-mobile-fix-nav/package/css/**` または `_scss/**` を変更した PR で、`class-vk-mobile-fix-nav.php` の `$version` 行が更新されていない場合に fail する番人（GitHub Actions）。
   - `pull_request` トリガー・`permissions: contents: read`（最小権限）・GitHub コンテキスト値は `env` 経由で受け取り（スクリプトインジェクション対策）。

> このライブラリは changelog ファイル（`readme.txt` / `CHANGELOG.md` 等）を持たないため changelog 追記はありません（#167 も同様に PHP のみ）。ユーザー向け changelog は各プロダクトへの再同期 PR 側で付与します。

## テスト（確認手順）

### 確認1: フロント CSS のバージョン指定

前提: vk-mobile-fix-nav が有効なサイト（Lightning 系テーマでスマホ固定ナビを表示する設定）。

1. スマホ幅（例: 375px）でフロントのページを開く → 画面下部に固定ナビが表示される。
2. ブラウザの「ページのソースを表示」または開発者ツールの Network タブで `vk-mobile-fix-nav.css` の読み込み URL を確認する。
   - → URL 末尾が **`?ver=0.1.0`** になっていること（`?ver=0.0.0` やタイムスタンプ `?ver=1752...` ではない）。

### 確認2: CI 番人（バージョン上げ忘れの検知）

1. このブランチから派生し、`vk-mobile-fix-nav/package/_scss/vk-mobile-fix-nav.scss`（または `css/vk-mobile-fix-nav.css`）を1行変更する。
2. `class-vk-mobile-fix-nav.php` の `$version` は**上げずに**PR を作成する。
   - → GitHub Actions の `vk-mobile-fix-nav version guard` が **fail** し、「`$version` を必ず更新してください」というエラーが出ること。
3. 続けて `$version` を `0.1.0` → `0.1.1` に上げて push する。
   - → 同ワークフローが **pass** すること。

（参考: この番人の grep 判定は、実際の履歴コミットで検証済み。バージョンを上げたコミットでは pass、#167 の「クラス変更したがバージョン据え置き」コミットでは fail することを確認しています。）

### デグレ確認

- `add_style()` は `wp_enqueue_style()` の第4引数を `filemtime()` の返り値から `self::$version`（静的文字列）へ変えただけで、読み込む CSS ファイル・登録ハンドル（`vk-mobile-fix-nav`）・依存関係は不変。CSS の内容自体は変更していないため、**見た目の変化はありません**（`?ver` の値のみが変わります）。
- `php -l` 構文チェック: エラーなし。

## 関連Issue

関連Issue: #166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - モバイルナビゲーションのバージョンを `0.1.0` に更新しました。
  - CSSのバージョン指定方法を整理し、読み込み時に常にモジュールのバージョンが反映されるよう改善しました。
- **運用**
  - CSS/SCSS変更時にバージョン更新が行われているかを自動確認し、未更新の場合は失敗するようワークフローを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->