### PR TITLE
[ 不具合修正 ] WordPress 7.1 のブロックエディタ iframe にフォント設定の CSS が読み込まれない不具合を修正

### DIFF
--- a/vk-font-selector/package/class-vk-font-selector.php
+++ b/vk-font-selector/package/class-vk-font-selector.php
@@ -71,7 +71,7 @@ if ( ! class_exists( 'Vk_Font_Selector' ) ) {
 			add_action( 'wp_head', array( __CLASS__, 'dynamic_header_css' ), 5 );
 			add_action( 'wp_footer', array( __CLASS__, 'load_web_fonts' ) );
 			add_action( 'admin_footer', array( __CLASS__, 'load_web_fonts' ) );
-			add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'dynamic_editor_css' ), 12 );
+			add_action( 'enqueue_block_assets', array( __CLASS__, 'dynamic_editor_css' ), 12 );
 		}
 
 		/**
@@ -478,6 +478,10 @@ if ( ! class_exists( 'Vk_Font_Selector' ) ) {
 		 * @return void
 		 */
 		public static function dynamic_editor_css() {
+			// enqueue_block_assets はフロントでも動くため、ブロックエディタでのみ読み込む.
+			if ( ! is_admin() ) {
+				return;
+			}
 
 			global $vk_font_selector_editor_style;
 			$options = get_option( 'vk_font_selector' );

--- a/vk-font-selector/tests/test-font-selector.php
+++ b/vk-font-selector/tests/test-font-selector.php
@@ -8,6 +8,42 @@
 class VK_Font_Selector_Test extends WP_UnitTestCase {
 
 	/**
+	 * テスト前のオプション値.
+	 *
+	 * @var array
+	 */
+	private $original_font_option;
+
+	/**
+	 * テスト前のグローバル値.
+	 *
+	 * @var array
+	 */
+	private $original_globals;
+
+	/**
+	 * テストの前処理.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$missing                    = new stdClass();
+		$original_font_option       = get_option( 'vk_font_selector', $missing );
+		$this->original_font_option = array(
+			'exists' => $missing !== $original_font_option,
+			'value'  => $original_font_option,
+		);
+
+		$this->original_globals = array();
+		foreach ( array( 'current_screen', 'vk_font_selector_editor_style' ) as $global_name ) {
+			$this->original_globals[ $global_name ] = array(
+				'exists' => array_key_exists( $global_name, $GLOBALS ),
+				'value'  => array_key_exists( $global_name, $GLOBALS ) ? $GLOBALS[ $global_name ] : null,
+			);
+		}
+	}
+
+	/**
 	 * Get font url
 	 */
 	public function test_get_web_fonts_url() {
@@ -72,6 +108,73 @@ class VK_Font_Selector_Test extends WP_UnitTestCase {
 			print 'return : ' . esc_attr( $return ) . PHP_EOL;
 			print 'correct : ' . esc_attr( $value['correct'] ) . PHP_EOL;
 			$this->assertEquals( $value['correct'], $return );
+		}
+	}
+
+	/**
+	 * Iframe 用アセット収集時にフォント設定の動的 CSS が含まれること.
+	 */
+	public function test__wp_get_iframed_editor_assets() {
+		update_option( 'vk_font_selector', array( 'title' => 'mincho' ) );
+		set_current_screen( 'post' );
+		$GLOBALS['vk_font_selector_editor_style'] = 'vk-font-selector-test';
+
+		wp_styles();
+		wp_scripts();
+		wp_register_style( 'vk-font-selector-test', false, array(), Vk_Font_Selector::$version );
+		add_action( 'enqueue_block_assets', array( $this, 'enqueue_test_editor_style' ), 10 );
+
+		$assets = _wp_get_iframed_editor_assets();
+
+		remove_action( 'enqueue_block_assets', array( $this, 'enqueue_test_editor_style' ), 10 );
+
+		$this->assertStringContainsString( '/* Font switch */', $assets['styles'] );
+		$this->assertStringContainsString( 'font-family:Hiragino Mincho ProN,"游明朝",serif;', $assets['styles'] );
+	}
+
+	/**
+	 * テスト用のスタイルを iframe の収集対象へ追加する.
+	 */
+	public function enqueue_test_editor_style() {
+		wp_enqueue_style( 'vk-font-selector-test' );
+	}
+
+	/**
+	 * 公開画面では編集画面用の動的 CSS を追加しないこと.
+	 */
+	public function test_dynamic_editor_css_on_front() {
+		update_option( 'vk_font_selector', array( 'title' => 'mincho' ) );
+		set_current_screen( 'front' );
+		$GLOBALS['vk_font_selector_editor_style'] = 'vk-font-selector-test';
+
+		wp_register_style( 'vk-font-selector-test', false, array(), Vk_Font_Selector::$version );
+		Vk_Font_Selector::dynamic_editor_css();
+
+		$this->assertFalse( wp_styles()->get_data( 'vk-font-selector-test', 'after' ) );
+	}
+
+	/**
+	 * テストの後処理.
+	 */
+	public function tearDown(): void {
+		remove_action( 'enqueue_block_assets', array( $this, 'enqueue_test_editor_style' ), 10 );
+		wp_dequeue_style( 'vk-font-selector-test' );
+		wp_deregister_style( 'vk-font-selector-test' );
+
+		if ( $this->original_font_option['exists'] ) {
+			update_option( 'vk_font_selector', $this->original_font_option['value'] );
+		} else {
+			delete_option( 'vk_font_selector' );
+		}
+
+		parent::tearDown();
+
+		foreach ( $this->original_globals as $global_name => $original_global ) {
+			if ( $original_global['exists'] ) {
+				$GLOBALS[ $global_name ] = $original_global['value'];
+			} else {
+				unset( $GLOBALS[ $global_name ] );
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #169
親 issue: https://github.com/vektor-inc/multi-repo-tasks/issues/32

関連対応:

- vektor-inc/lightning-g3-pro-unit#338（同梱版のフォントCSSが iframe に届かない問題を含む調査）
- vektor-inc/lightning-g3-pro-unit#339（同梱版で iframe 収集を妨げる判定を削除した対応）

## 概要

| 対象 | 役割 |
|---|---|
| WordPress コア | ブロックエディタの iframe（編集内容を表示する内側の画面）へ入れるCSSを収集する |
| VK Font Selector | 利用者が選択したフォントから編集画面用の動的CSSを生成する |

編集画面用のフォントCSSを、エディタUI用アセットのフック（`enqueue_block_editor_assets`）へ登録していたため、WordPress 7.1のiframe用アセット収集から呼ばれませんでした。

登録先を、編集内容と公開画面に共通するアセットのフック（`enqueue_block_assets`）へ変更しました。このフックは公開画面でも実行されるため、`! is_admin()` のときは処理を終了し、公開側の既存出力と重複しないようにしています。

WordPressコアがiframe収集中に意図的に無効化する、エディタUI用アセットの読み込み判定（`wp_should_load_block_editor_scripts_and_styles()`）は追加していません。

## 変更内容

- フォント設定の動的CSSを `enqueue_block_assets` から追加するよう変更
- 公開画面では編集画面用CSSを追加しないガードを追加
- iframe用アセットの収集結果へ選択したフォントのCSSが含まれる回帰テストを追加
- 公開画面で編集画面用CSSが追加されない回帰テストを追加

## 確認手順

### 前提条件

- VK Font Selectorを組み込んだ製品
- WordPress 7.1
- フォント設定の見出しフォントを「明朝」に設定

### Before（修正前）

1. 投稿編集画面を開く
2. ブラウザの開発者ツールで、編集内容を表示するiframe内のスタイルを確認する
   → `/* Font switch */` と明朝の `font-family` を含む動的CSSが存在しない
3. 公開画面で `dynamic_editor_css()` を実行する
   → 編集画面用の動的CSSが追加される

### After（修正後）

1. 投稿編集画面を開く
2. ブラウザの開発者ツールで、編集内容を表示するiframe内のスタイルを確認する
   → `/* Font switch */` と明朝の `font-family` を含む動的CSSが存在する
3. 公開画面を開く
   → 編集画面用の動的CSSは追加されず、既存の公開画面用フォントCSSだけが出力される

## テスト結果

- 回帰テスト（修正前）: `2 tests, 2 failures`
- VK Font Selector対象テスト（修正後）: `3 tests, 10 assertions` 成功
- PHP lint: 変更した2ファイルとも構文エラーなし
- `git diff --check`: 問題なし
- PHPCS: 変更前後で既存違反数が同じで、新規違反なし

## Changelog

このリポジトリの `readme.md` にはChangelogセクションがないため、追記していません。

## スクリーンショット

表示デザインを変更する修正ではなく、既存のフォントCSSをiframeへ渡す読み込み経路の修正のため省略します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ブロックエディターの iframe 環境でも、動的なフォント用 CSS が正しく適用されるようになりました。
  * 公開画面にはエディター用 CSS が追加されないようになり、フロントエンドへの不要な影響を防止します。

* **テスト**
  * エディターと公開画面での CSS 適用状況を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->